### PR TITLE
[NOTRACKER] Fixed an index slice bug

### DIFF
--- a/descriptor.go
+++ b/descriptor.go
@@ -40,6 +40,13 @@ func (r *descriptorReader) Read(p []byte) (n int, err error) {
 	discard := n
 	s := 16
 	for !r.eof && s < n {
+
+		//Determine if we have enough buffer data to read
+		if s >= len(z)-4 {
+			r.eof = true
+			return n, io.EOF
+		}
+
 		i := bytes.Index(z[s:len(z)-4], sigBytes) + s
 		if i == -1 {
 			break

--- a/reader_test.go
+++ b/reader_test.go
@@ -9,14 +9,6 @@ import (
 	"testing"
 )
 
-func TestReader(t *testing.T) {
-	testReader(t, []byte(`<poc><firstName>Juan</firstName></poc>`))
-
-	s := new(bytes.Buffer)
-	io.Copy(s, io.LimitReader(rand.New(rand.NewSource(1)), 16384))
-	testReader(t, s.Bytes())
-}
-
 func testReader(t *testing.T, s []byte) {
 
 	var wbuf bytes.Buffer
@@ -59,6 +51,74 @@ func testReader(t *testing.T, s []byte) {
 			if bytes.Compare(s, s2) != 0 {
 				t.Fatal("Decompressed data does not match original")
 			}
+		}
+	}
+}
+
+func TestReader(t *testing.T) {
+	testReader(t, []byte(`<poc><firstName>Juan</firstName></poc>`))
+
+	s := new(bytes.Buffer)
+	io.Copy(s, io.LimitReader(rand.New(rand.NewSource(1)), 16384))
+	testReader(t, s.Bytes())
+}
+
+func TestHeaderShortRead(t *testing.T) {
+	zbuf := bytes.Buffer{}
+	zwtr := zip.NewWriter(&zbuf)
+	zw, err := zwtr.Create("tmp.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Write file 1
+	if _, err := zw.Write([]byte(`<poc><firstName>Juan</firstName><lastName>RodRiehakelkjd lkbug</lastName><department>Engineering Department</department></poc>`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := io.Copy(zw, io.LimitReader(rand.New(rand.NewSource(1)), 16384)); err != nil {
+		t.Fatal(err)
+	}
+
+	zw, err = zwtr.Create("tmp.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Write file 2
+	if _, err := zw.Write([]byte(`{"proc":{"firstName":"Juan","lastName":"RodRiehakelkjd","department":"Engineering Department"}}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := io.Copy(zw, io.LimitReader(rand.New(rand.NewSource(3)), 16384)); err != nil {
+		t.Fatal(err)
+	}
+
+	//Close the zip writer
+	if err := zwtr.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	//Find the second magic marker so we can test the header break issue
+	idx := bytes.Index(zbuf.Bytes()[4:], []byte{0x50, 0x4b, 0x03, 0x04})
+	if idx < 0 {
+		panic("Unable to find magic file marker")
+	}
+
+	//Get the magic marker
+	//b := zbuf.Bytes()[:idx+4]
+	b := zbuf.Bytes()
+	b = b[:idx+6]
+
+	//Read
+	zr := NewReader(bytes.NewReader(b))
+	for {
+		//We are waiting for an unexepected EOF
+		_, err := zr.Next()
+		if err == io.ErrUnexpectedEOF {
+			break
+		} else if err != nil {
+			t.Fatal(err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Fixed a bug where data with zips that unexpectedly had an EOF does not
crash on a slice error when looking for the magic markers.