### PR TITLE
Add Compass component config (compass.yml)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: zipstream
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/4ca7c9ac-fd10-4c95-acc2-fddb5b8708a4
+configVersion: 1
+typeId: LIBRARY
+ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-13 # Events - OBC (263)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/zipstream


### PR DESCRIPTION
Onboards `zipstream` to Compass (replaces the stale compass-github-importer PR).

- typeId: `LIBRARY`
- owner: Events - OBC (263)
- component: `4ca7c9ac-fd10-4c95-acc2-fddb5b8708a4`